### PR TITLE
update docker-compose.yml, node/index.js, requirements.txt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,6 @@ services:
   nginx:
     build: 
       context: ./nginx
-      cache_from:
-        - nginx:latest
-      args:
-        BUILDKIT_INLINE_CACHE: 1
     image: nginx:8888
     #container_name: nginx
     ports:
@@ -22,10 +18,6 @@ services:
   web:
     build:
       context: .
-      cache_from:
-        - django:gunicorn4
-      args:
-        BUILDKIT_INLINE_CACHE: 1
     image: django:gunicorn4
     #container_name: django
     command: /bin/bash -c "source env/bin/activate && gunicorn --bind 0.0.0.0:8000 config.wsgi:application"
@@ -41,10 +33,6 @@ services:
   worker:
     build:
       context: .
-      cache_from:
-        - django:gunicorn4
-      args:
-        BUILDKIT_INLINE_CACHE: 1
     image: django:gunicorn4
     #container_name: worker
     # command: celery -A ClothesSeparationAPI.tasks worker --loglevel=info
@@ -66,10 +54,6 @@ services:
   rabbit:
     build:
       context: ./rabbit
-      cache_from:
-        - rabbitmq:3-management
-      args:
-        BUILDKIT_INLINE_CACHE: 1
     image: rabbitmq:3-management
     #container_name: rabbit
     expose:
@@ -85,18 +69,19 @@ services:
   node:
     build:
       context: ./node
-      cache_from:
-        - node:api
-      args:
-        BUILDKIT_INLINE_CACHE: 1
     image: node:api
     #container_name: node
     ports:
       - "5000:5000"
     command: node index.js
     environment:
-      - MONGO_URI=insert mongo uri here
-      - NODE_ENV=dev
+      - MONGO_URI=mongodb://mongo:27017
+      - NODE_ENV=production
+
+  mongo:
+    image: mongo:latest
+    expose:
+      - "27017"
 
 volumes:
   test_volume: {}

--- a/node/index.js
+++ b/node/index.js
@@ -12,7 +12,6 @@ const { User } = require('./models/User')
 const mongoose = require('mongoose')
 const { response } = require('express')
 mongoose.connect(config.mongoURI, {
-  useNewUrlParser: true, useUnifiedTopology: true, useCreateIndex: true, useFindAndModify: false
 }).then(() => console.log('MongoDB Connected...'))
   .catch(err => console.log(err))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Django==3.1.3
 gunicorn==20.0.4
 Pillow==8.1.2
 celery==5.0.5
-tensorflow==2.2
+tensorflow==2.4
 opencv-python==4.5.1.48


### PR DESCRIPTION
docker-compose 에서 외부 mongodb를 사용하지 않고 컨테이너를 추가하여
사용하도록 수정. 외부 mongodb의 URL을 node/index.js에 환경변수로 사
용했는데, 이를 mongodb://mongo:27017로 수정. 그리고 mongodb 6.0 이상
버전에서 사용하는 형태에 맞게 connect 부분 수정. requirements.txt 에
는 기존의 tensorflow 2.2 버전을 2.4 버전으로 변경(용량 감소로 인한빌
드시간 감소)